### PR TITLE
Fix broken links in TOC

### DIFF
--- a/amr.md
+++ b/amr.md
@@ -9,14 +9,14 @@ Ulf Hermjakob, Kevin Knight, Philipp Koehn, Martha Palmer, Nathan Schneider_
 
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [Abstract Meaning Representation (AMR) 1.2 Specification](#abstract-meaning-representation-amr-10-specification)
+- [Abstract Meaning Representation (AMR) 1.2.2 Specification](#abstract-meaning-representation-amr-122-specification)
 - [Part I. Introduction](#part-i-introduction)
    - [Example](#example)
 	- [Abstraction away from English](#abstraction-away-from-english)
 	- [More Logical than Syntax](#more-logical-than-syntax)
 	- [Focus](#focus)
 	- [AMR slogans](#amr-slogans)
-	- [Limitations of AMR 1.2](#limitations-of-amr-11)
+	- [Limitations of AMR 1.2](#limitations-of-amr-12)
 - [Part II.  Concepts and relations](#part-ii--concepts-and-relations)
 - [Part III.  Phenomena](#part-iii--phenomena)
 	- [Core roles](#core-roles)


### PR DESCRIPTION
Some of the links in the TOC were broken, probably due to the TOC not being updated after some changes. This PR simply synchronises the TOC with the contents without making any changes to the contents of the specification.

As a small aside, [DocToc](http://doctoc.herokuapp.com/) seems to be out-of-order, see thlorenz/doctoc-web#9. Considering the age of the issue, a future fix seems unlikely.