### PR TITLE
Fix #172: put time entity in quotes

### DIFF
--- a/amr.md
+++ b/amr.md
@@ -3782,7 +3782,7 @@ These entities are described in standard, canonical forms:
    :month 2
    :day 29
    :weekday (w / wednesday)
-   :time 16:30
+   :time "16:30"
    :timezone (z / PST))
 ```
 
@@ -3790,7 +3790,7 @@ These entities are described in standard, canonical forms:
 
 ```lisp
 (d / date-entity
-   :time 16:30)
+   :time "16:30")
 ```
 
 > 16:30


### PR DESCRIPTION
In #172, it was pointed out that the following AMR from the guidelines cannot be parsed with Smatch:

```lisp
(d / date-entity
   :month 2
   :day 29
   :weekday (w / wednesday)
   :time 16:30
   :timezone (z / PST))
```

The time `16:30` [should be in quotes](http://www.isi.edu/~ulf/amr/lib/popup/date.html), as pointed out by @nschneid. This PR makes that change.